### PR TITLE
Fix hash

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -40,8 +40,13 @@ module.exports = function createHistory (options, onChange) {
   }
 
   function url () {
-    if (mode === 'history') return location.pathname + location.search + '#' + getHash()
-    if (mode === 'hash') return getHash()
+    var hash = getHash()
+    if (mode === 'history') {
+      var url = location.pathname + location.search
+      if (hash !== '') url += '#' + hash
+      return url
+    }
+    if (mode === 'hash') return hash === '' ? '/' : hash
     if (mode === 'memory') return memory[memory.length - 1]
   }
 
@@ -49,6 +54,6 @@ module.exports = function createHistory (options, onChange) {
   // in Firefox where location.hash will always be decoded.
   function getHash () {
     var match = location.href.match(/#(.*)$/)
-    return match ? match[1].replace('#', '') : '/'
+    return match ? match[1].replace('#', '') : ''
   }
 }

--- a/src/history.js
+++ b/src/history.js
@@ -40,7 +40,7 @@ module.exports = function createHistory (options, onChange) {
   }
 
   function url () {
-    if (mode === 'history') return location.pathname + location.search
+    if (mode === 'history') return location.pathname + location.search + '#' + getHash()
     if (mode === 'hash') return getHash()
     if (mode === 'memory') return memory[memory.length - 1]
   }

--- a/src/router.js
+++ b/src/router.js
@@ -25,7 +25,7 @@ module.exports = function createRouter (routes, options) {
     history.push(url)
   }
 
-  function transition (url) {
+  function transition () {
     var route = match(routes, history.url(), qs)
     route && onTransition(route, router.data(route.pattern))
   }


### PR DESCRIPTION
Right now the hash is stripped from the `url` passed to the matcher meaning on transitions, `router.hash === ''` everytime