### PR TITLE
Fix hash only links

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -17,11 +17,17 @@ module.exports = function createRouter (routes, options) {
   var unintercept = options.interceptLinks && links.intercept(shouldIntercept, onClick)
 
   function shouldIntercept (url) {
+    if (/^#/.test(url)) {
+      url = history.url().replace(/#.*/, url)
+    }
     return match(routes, url, qs)
   }
 
   function onClick (e, url) {
     e.preventDefault()
+    if (/^#/.test(url)) {
+      url = history.url().replace(/#.*/, url)
+    }
     history.push(url)
   }
 


### PR DESCRIPTION
It seems space-router doesn't handle any hash-only links correctly (e.g. #my-section) as the url passed to the match function is just `#my-section` meaning it will always just match the / route.