### PR TITLE
Fix correctness bugs in href/qs/redirects and add TypeScript types

### DIFF
--- a/dist/cjs/history.js
+++ b/dist/cjs/history.js
@@ -8,14 +8,13 @@ Object.defineProperty(exports, "createHistory", {
         return createHistory;
     }
 });
-function createHistory(options) {
+function createHistory() {
+    var options = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
     var sync = options.sync;
-    var mode = options.mode;
+    var mode = options.mode || 'history';
     var raf;
-    var onPop;
+    var listener;
     var memory = [];
-    var off;
-    var destroyed = false;
     if (typeof window === 'undefined') {
         mode = 'memory';
         raf = sync ? function(cb) {
@@ -29,35 +28,27 @@ function createHistory(options) {
             mode = 'hash';
         }
     }
+    function emit() {
+        if (listener) listener(getUrl());
+    }
     function listen(onChange) {
-        onPop = function onPop() {
-            return onChange(getUrl());
-        };
+        if (listener) throw new Error('Already listening');
+        listener = onChange;
+        var off;
         if (mode !== 'memory') {
-            off = on(window, mode === 'history' ? 'popstate' : 'hashchange', onPop);
-            raf(onPop);
+            off = on(window, mode === 'history' ? 'popstate' : 'hashchange', emit);
+            raf(emit);
         }
         return function() {
-            destroyed = true;
+            listener = null;
             if (off) off();
         };
     }
-    return {
-        listen: listen,
-        getUrl: getUrl,
-        push: function push(url) {
-            go(url);
-        },
-        replace: function replace(url) {
-            go(url, true);
-        }
-    };
     function go(url, replace) {
-        if (destroyed) return;
         url = url.replace(/^\/?#?\/?/, '/').replace(/\/$/, '') || '/';
         if (mode === 'history') {
             history[replace ? 'replaceState' : 'pushState']({}, '', url);
-            raf(onPop);
+            raf(emit);
         } else if (mode === 'hash') {
             location[replace ? 'replace' : 'assign']('#' + url);
         } else if (mode === 'memory') {
@@ -66,7 +57,7 @@ function createHistory(options) {
             } else {
                 memory.push(url);
             }
-            raf(onPop);
+            raf(emit);
         }
     }
     function getUrl() {
@@ -89,8 +80,18 @@ function createHistory(options) {
     // in Firefox where location.hash will always be decoded.
     function getHash() {
         var match = location.href.match(/#(.*)$/);
-        return match ? match[1].replace('#', '') : '';
+        return match ? match[1] : '';
     }
+    return {
+        listen: listen,
+        getUrl: getUrl,
+        push: function push(url) {
+            go(url);
+        },
+        replace: function replace(url) {
+            go(url, true);
+        }
+    };
 }
 function on(el, type, fn) {
     el.addEventListener(type, fn, false);

--- a/dist/cjs/qs.js
+++ b/dist/cjs/qs.js
@@ -11,17 +11,23 @@ Object.defineProperty(exports, "qs", {
 var qs = {
     parse: function parse(queryString) {
         return queryString.split('&').reduce(function(acc, pair) {
-            var parts = pair.split('=');
-            acc[parts[0]] = decodeURIComponent(parts[1]);
+            if (!pair) return acc;
+            var i = pair.indexOf('=');
+            var key = decode(i < 0 ? pair : pair.slice(0, i));
+            var val = i < 0 ? '' : decode(pair.slice(i + 1));
+            acc[key] = val;
             return acc;
         }, {});
     },
     stringify: function stringify(query) {
         return Object.keys(query).reduce(function(acc, key) {
             if (query[key] !== undefined) {
-                acc.push(key + '=' + encodeURIComponent(query[key]));
+                acc.push(encodeURIComponent(key) + '=' + encodeURIComponent(query[key]));
             }
             return acc;
         }, []).join('&');
     }
 };
+function decode(s) {
+    return decodeURIComponent(s.replace(/\+/g, ' '));
+}

--- a/dist/cjs/router.js
+++ b/dist/cjs/router.js
@@ -110,31 +110,61 @@ function _object_without_properties_loose(source, excluded) {
     }
     return target;
 }
+var PARAM_RE = /:([A-Za-z0-9_]+)([+*?])?/g;
+var MAX_REDIRECTS = 10;
 function createRouter() {
     var options = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
-    var history = null;
-    var routes = [];
     var mode = options.mode || 'history';
     var qs = options.qs || _qs.qs;
     var sync = options.sync || false;
+    var history = (0, _history.createHistory)({
+        mode: mode,
+        sync: sync
+    });
+    var routes = [];
     var router = {
         listen: function listen(routeMap, cb) {
-            if (history) {
-                throw new Error('Already listening');
-            }
             routes = flatten(routeMap);
-            history = (0, _history.createHistory)({
-                mode: mode,
-                sync: sync
+            var redirects = 0;
+            return history.listen(function(url) {
+                var route = router.match(url);
+                if (!route) {
+                    redirects = 0;
+                    return;
+                }
+                var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
+                try {
+                    for(var _iterator = route.data[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+                        var r = _step.value;
+                        if (r.redirect) {
+                            if (++redirects > MAX_REDIRECTS) {
+                                redirects = 0;
+                                throw new Error('space-router: too many redirects');
+                            }
+                            var target = typeof r.redirect === 'function' ? r.redirect(route) : r.redirect;
+                            return router.navigate({
+                                url: router.href(target),
+                                replace: true
+                            });
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                } finally{
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return != null) {
+                            _iterator.return();
+                        }
+                    } finally{
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                }
+                redirects = 0;
+                if (cb) cb(route);
             });
-            var dispose = history.listen(function(url) {
-                return transition(router, url, cb);
-            });
-            return function() {
-                dispose();
-                history = null;
-                routes = [];
-            };
         },
         navigate: function navigate(to, curr) {
             if (typeof to === 'string') {
@@ -164,8 +194,14 @@ function createRouter() {
             }
             var url = to.pathname || '/';
             if (to.params) {
-                Object.keys(to.params).forEach(function(param) {
-                    url = url.replace(':' + param, to.params[param]);
+                var params = to.params;
+                url = url.replace(PARAM_RE, function(m, name, flag) {
+                    var v = params[name];
+                    if (v == null) return m;
+                    if (flag === '+' || flag === '*') {
+                        return String(v).split('/').map(encodeURIComponent).join('/');
+                    }
+                    return encodeURIComponent(v);
                 });
             }
             if (to.query && Object.keys(to.query).length) {
@@ -218,44 +254,6 @@ function flatten(routeMap) {
     }
     addLevel(routeMap);
     return routes;
-}
-function transition(router, url, onNavigated) {
-    var route = router.match(url);
-    if (route) {
-        var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-        try {
-            for(var _iterator = route.data[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-                var r = _step.value;
-                if (r.redirect) {
-                    var _$url = redirectUrl(router, r.redirect, route);
-                    return router.navigate({
-                        url: _$url,
-                        replace: true
-                    });
-                }
-            }
-        } catch (err) {
-            _didIteratorError = true;
-            _iteratorError = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion && _iterator.return != null) {
-                    _iterator.return();
-                }
-            } finally{
-                if (_didIteratorError) {
-                    throw _iteratorError;
-                }
-            }
-        }
-        if (onNavigated) onNavigated(route);
-    }
-}
-function redirectUrl(router, redirect, matchingRoute) {
-    if (typeof redirect === 'function') {
-        redirect = redirect(matchingRoute);
-    }
-    return router.href(redirect);
 }
 function data(routes, matchingRoute) {
     for(var i = 0; i < routes.length; i++){

--- a/dist/esm/history.js
+++ b/dist/esm/history.js
@@ -1,11 +1,10 @@
-export function createHistory(options) {
+export function createHistory() {
+    var options = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
     var sync = options.sync;
-    var mode = options.mode;
+    var mode = options.mode || 'history';
     var raf;
-    var onPop;
+    var listener;
     var memory = [];
-    var off;
-    var destroyed = false;
     if (typeof window === 'undefined') {
         mode = 'memory';
         raf = sync ? function(cb) {
@@ -19,35 +18,27 @@ export function createHistory(options) {
             mode = 'hash';
         }
     }
+    function emit() {
+        if (listener) listener(getUrl());
+    }
     function listen(onChange) {
-        onPop = function onPop() {
-            return onChange(getUrl());
-        };
+        if (listener) throw new Error('Already listening');
+        listener = onChange;
+        var off;
         if (mode !== 'memory') {
-            off = on(window, mode === 'history' ? 'popstate' : 'hashchange', onPop);
-            raf(onPop);
+            off = on(window, mode === 'history' ? 'popstate' : 'hashchange', emit);
+            raf(emit);
         }
         return function() {
-            destroyed = true;
+            listener = null;
             if (off) off();
         };
     }
-    return {
-        listen: listen,
-        getUrl: getUrl,
-        push: function push(url) {
-            go(url);
-        },
-        replace: function replace(url) {
-            go(url, true);
-        }
-    };
     function go(url, replace) {
-        if (destroyed) return;
         url = url.replace(/^\/?#?\/?/, '/').replace(/\/$/, '') || '/';
         if (mode === 'history') {
             history[replace ? 'replaceState' : 'pushState']({}, '', url);
-            raf(onPop);
+            raf(emit);
         } else if (mode === 'hash') {
             location[replace ? 'replace' : 'assign']('#' + url);
         } else if (mode === 'memory') {
@@ -56,7 +47,7 @@ export function createHistory(options) {
             } else {
                 memory.push(url);
             }
-            raf(onPop);
+            raf(emit);
         }
     }
     function getUrl() {
@@ -79,8 +70,18 @@ export function createHistory(options) {
     // in Firefox where location.hash will always be decoded.
     function getHash() {
         var match = location.href.match(/#(.*)$/);
-        return match ? match[1].replace('#', '') : '';
+        return match ? match[1] : '';
     }
+    return {
+        listen: listen,
+        getUrl: getUrl,
+        push: function push(url) {
+            go(url);
+        },
+        replace: function replace(url) {
+            go(url, true);
+        }
+    };
 }
 function on(el, type, fn) {
     el.addEventListener(type, fn, false);

--- a/dist/esm/qs.js
+++ b/dist/esm/qs.js
@@ -1,17 +1,23 @@
 export var qs = {
     parse: function parse(queryString) {
         return queryString.split('&').reduce(function(acc, pair) {
-            var parts = pair.split('=');
-            acc[parts[0]] = decodeURIComponent(parts[1]);
+            if (!pair) return acc;
+            var i = pair.indexOf('=');
+            var key = decode(i < 0 ? pair : pair.slice(0, i));
+            var val = i < 0 ? '' : decode(pair.slice(i + 1));
+            acc[key] = val;
             return acc;
         }, {});
     },
     stringify: function stringify(query) {
         return Object.keys(query).reduce(function(acc, key) {
             if (query[key] !== undefined) {
-                acc.push(key + '=' + encodeURIComponent(query[key]));
+                acc.push(encodeURIComponent(key) + '=' + encodeURIComponent(query[key]));
             }
             return acc;
         }, []).join('&');
     }
 };
+function decode(s) {
+    return decodeURIComponent(s.replace(/\+/g, ' '));
+}

--- a/dist/esm/router.js
+++ b/dist/esm/router.js
@@ -89,31 +89,61 @@ function _object_without_properties_loose(source, excluded) {
 import { match as findMatch } from './match';
 import { createHistory } from './history';
 import { qs as defaultQs } from './qs';
+var PARAM_RE = /:([A-Za-z0-9_]+)([+*?])?/g;
+var MAX_REDIRECTS = 10;
 export function createRouter() {
     var options = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
-    var history = null;
-    var routes = [];
     var mode = options.mode || 'history';
     var qs = options.qs || defaultQs;
     var sync = options.sync || false;
+    var history = createHistory({
+        mode: mode,
+        sync: sync
+    });
+    var routes = [];
     var router = {
         listen: function listen(routeMap, cb) {
-            if (history) {
-                throw new Error('Already listening');
-            }
             routes = flatten(routeMap);
-            history = createHistory({
-                mode: mode,
-                sync: sync
+            var redirects = 0;
+            return history.listen(function(url) {
+                var route = router.match(url);
+                if (!route) {
+                    redirects = 0;
+                    return;
+                }
+                var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
+                try {
+                    for(var _iterator = route.data[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+                        var r = _step.value;
+                        if (r.redirect) {
+                            if (++redirects > MAX_REDIRECTS) {
+                                redirects = 0;
+                                throw new Error('space-router: too many redirects');
+                            }
+                            var target = typeof r.redirect === 'function' ? r.redirect(route) : r.redirect;
+                            return router.navigate({
+                                url: router.href(target),
+                                replace: true
+                            });
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                } finally{
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return != null) {
+                            _iterator.return();
+                        }
+                    } finally{
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                }
+                redirects = 0;
+                if (cb) cb(route);
             });
-            var dispose = history.listen(function(url) {
-                return transition(router, url, cb);
-            });
-            return function() {
-                dispose();
-                history = null;
-                routes = [];
-            };
         },
         navigate: function navigate(to, curr) {
             if (typeof to === 'string') {
@@ -143,8 +173,14 @@ export function createRouter() {
             }
             var url = to.pathname || '/';
             if (to.params) {
-                Object.keys(to.params).forEach(function(param) {
-                    url = url.replace(':' + param, to.params[param]);
+                var params = to.params;
+                url = url.replace(PARAM_RE, function(m, name, flag) {
+                    var v = params[name];
+                    if (v == null) return m;
+                    if (flag === '+' || flag === '*') {
+                        return String(v).split('/').map(encodeURIComponent).join('/');
+                    }
+                    return encodeURIComponent(v);
                 });
             }
             if (to.query && Object.keys(to.query).length) {
@@ -197,44 +233,6 @@ export function flatten(routeMap) {
     }
     addLevel(routeMap);
     return routes;
-}
-function transition(router, url, onNavigated) {
-    var route = router.match(url);
-    if (route) {
-        var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-        try {
-            for(var _iterator = route.data[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-                var r = _step.value;
-                if (r.redirect) {
-                    var _$url = redirectUrl(router, r.redirect, route);
-                    return router.navigate({
-                        url: _$url,
-                        replace: true
-                    });
-                }
-            }
-        } catch (err) {
-            _didIteratorError = true;
-            _iteratorError = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion && _iterator.return != null) {
-                    _iterator.return();
-                }
-            } finally{
-                if (_didIteratorError) {
-                    throw _iteratorError;
-                }
-            }
-        }
-        if (onNavigated) onNavigated(route);
-    }
-}
-function redirectUrl(router, redirect, matchingRoute) {
-    if (typeof redirect === 'function') {
-        redirect = redirect(matchingRoute);
-    }
-    return router.href(redirect);
 }
 function data(routes, matchingRoute) {
     for(var i = 0; i < routes.length; i++){

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,95 @@
+export type Mode = 'history' | 'hash' | 'memory'
+
+export interface Qs {
+  parse(queryString: string): Record<string, string>
+  stringify(query: Record<string, unknown>): string
+}
+
+export interface RouterOptions {
+  /** URL strategy. Defaults to `history`. Forced to `memory` when there is no `window`. */
+  mode?: Mode
+  /** Custom query string parser. Defaults to the built-in `qs`. */
+  qs?: Qs
+  /** Synchronously notify listeners on navigation (skips `requestAnimationFrame`). */
+  sync?: boolean
+}
+
+export interface Route<Data = Record<string, unknown>> {
+  /** The full relative URL the router observed. */
+  url: string
+  /** The `pathname` portion of the URL, without query or hash. */
+  pathname: string
+  /** Params extracted from the matched pattern's named segments. */
+  params: Record<string, string>
+  /** Query parsed via the active `qs.parse`. */
+  query: Record<string, string>
+  /** Raw query string including the leading `?` (or empty). */
+  search: string
+  /** Hash fragment including the leading `#` (or empty). */
+  hash: string
+  /** The pattern that matched, e.g. `/user/:id`. */
+  pattern: string
+  /** Stack of metadata objects from each matched route level (outermost first). */
+  data: Data[]
+}
+
+export interface NavigateTarget {
+  /** A pre-built URL string. If set, all other fields are ignored. */
+  url?: string
+  /** Pathname (may include `:name` segments to be filled by `params`). */
+  pathname?: string
+  /** Values for any `:name` segments in `pathname`. */
+  params?: Record<string, string | number>
+  /** Query, passed through `qs.stringify`. Pass `null` (with `merge`) to clear. */
+  query?: Record<string, unknown> | null
+  /** Hash fragment, with or without leading `#`. Pass `null` (with `merge`) to clear. */
+  hash?: string | null
+  /** Use `replaceState` instead of `pushState`. */
+  replace?: boolean
+  /** Merge with the current route (params/query/hash carry over unless overridden). */
+  merge?: boolean
+}
+
+export type To = string | NavigateTarget
+
+export type Redirect<Data = Record<string, unknown>> = To | ((route: Route<Data>) => To)
+
+export type RouteDefinition<Data = Record<string, unknown>> = Data & {
+  /** URL pattern, e.g. `/user/:id`, `/files/:path+`, or `*` for a catch-all. */
+  path?: string
+  /** Redirect target. May be a URL, a `NavigateTarget`, or a function returning one. */
+  redirect?: Redirect<Data>
+  /** Nested routes (each must define its own full `path`). */
+  routes?: RouteDefinition<Data>[]
+}
+
+export interface Router<Data = Record<string, unknown>> {
+  /** Start listening for URL changes. Returns a dispose function. */
+  listen(routes: RouteDefinition<Data>[], onChange?: (route: Route<Data>) => void): () => void
+  /** Navigate to a new URL. */
+  navigate(to: To, curr?: Route<Data>): void
+  /** Build a URL string from a navigation target. */
+  href(to: To, curr?: Route<Data>): string
+  /** Match a URL against the registered routes. */
+  match(url: string): Route<Data> | undefined
+  /** Read the current URL (path + search + hash). */
+  getUrl(): string
+}
+
+export function createRouter<Data = Record<string, unknown>>(options?: RouterOptions): Router<Data>
+
+export function merge(
+  curr: Partial<Route> | NavigateTarget | undefined,
+  to: NavigateTarget,
+): NavigateTarget
+
+export const qs: Qs
+
+export interface History {
+  listen(onChange: (url: string) => void): () => void
+  getUrl(): string
+  push(url: string): void
+  replace(url: string): void
+}
+
+export function createHistory(options?: { mode?: Mode; sync?: boolean }): History

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.9.5",
   "main": "dist/cjs",
   "module": "dist/esm",
+  "types": "./index.d.ts",
   "license": "ICS",
   "repository": {
     "type": "git",

--- a/src/history.js
+++ b/src/history.js
@@ -1,12 +1,10 @@
-export function createHistory(options) {
+export function createHistory(options = {}) {
   const sync = options.sync
-  let mode = options.mode
+  let mode = options.mode || 'history'
   let raf
-  let onPop
+  let listener
 
   const memory = []
-  let off
-  let destroyed = false
 
   if (typeof window === 'undefined') {
     mode = 'memory'
@@ -18,37 +16,29 @@ export function createHistory(options) {
     }
   }
 
+  function emit() {
+    if (listener) listener(getUrl())
+  }
+
   function listen(onChange) {
-    onPop = () => onChange(getUrl())
-
+    if (listener) throw new Error('Already listening')
+    listener = onChange
+    let off
     if (mode !== 'memory') {
-      off = on(window, mode === 'history' ? 'popstate' : 'hashchange', onPop)
-      raf(onPop)
+      off = on(window, mode === 'history' ? 'popstate' : 'hashchange', emit)
+      raf(emit)
     }
-
     return () => {
-      destroyed = true
+      listener = null
       if (off) off()
     }
   }
 
-  return {
-    listen,
-    getUrl,
-    push(url) {
-      go(url)
-    },
-    replace(url) {
-      go(url, true)
-    },
-  }
-
   function go(url, replace) {
-    if (destroyed) return
     url = url.replace(/^\/?#?\/?/, '/').replace(/\/$/, '') || '/'
     if (mode === 'history') {
       history[replace ? 'replaceState' : 'pushState']({}, '', url)
-      raf(onPop)
+      raf(emit)
     } else if (mode === 'hash') {
       location[replace ? 'replace' : 'assign']('#' + url)
     } else if (mode === 'memory') {
@@ -57,7 +47,7 @@ export function createHistory(options) {
       } else {
         memory.push(url)
       }
-      raf(onPop)
+      raf(emit)
     }
   }
 
@@ -85,7 +75,18 @@ export function createHistory(options) {
   // in Firefox where location.hash will always be decoded.
   function getHash() {
     const match = location.href.match(/#(.*)$/)
-    return match ? match[1].replace('#', '') : ''
+    return match ? match[1] : ''
+  }
+
+  return {
+    listen,
+    getUrl,
+    push(url) {
+      go(url)
+    },
+    replace(url) {
+      go(url, true)
+    },
   }
 }
 

--- a/src/qs.js
+++ b/src/qs.js
@@ -1,8 +1,11 @@
 export const qs = {
   parse(queryString) {
     return queryString.split('&').reduce((acc, pair) => {
-      const parts = pair.split('=')
-      acc[parts[0]] = decodeURIComponent(parts[1])
+      if (!pair) return acc
+      const i = pair.indexOf('=')
+      const key = decode(i < 0 ? pair : pair.slice(0, i))
+      const val = i < 0 ? '' : decode(pair.slice(i + 1))
+      acc[key] = val
       return acc
     }, {})
   },
@@ -11,10 +14,14 @@ export const qs = {
     return Object.keys(query)
       .reduce((acc, key) => {
         if (query[key] !== undefined) {
-          acc.push(key + '=' + encodeURIComponent(query[key]))
+          acc.push(encodeURIComponent(key) + '=' + encodeURIComponent(query[key]))
         }
         return acc
       }, [])
       .join('&')
   },
+}
+
+function decode(s) {
+  return decodeURIComponent(s.replace(/\+/g, ' '))
 }

--- a/src/router.js
+++ b/src/router.js
@@ -2,28 +2,40 @@ import { match as findMatch } from './match'
 import { createHistory } from './history'
 import { qs as defaultQs } from './qs'
 
+const PARAM_RE = /:([A-Za-z0-9_]+)([+*?])?/g
+const MAX_REDIRECTS = 10
+
 export function createRouter(options = {}) {
-  let history = null
-  let routes = []
   const mode = options.mode || 'history'
   const qs = options.qs || defaultQs
   const sync = options.sync || false
+  const history = createHistory({ mode, sync })
+
+  let routes = []
 
   const router = {
     listen(routeMap, cb) {
-      if (history) {
-        throw new Error('Already listening')
-      }
-
       routes = flatten(routeMap)
-      history = createHistory({ mode, sync })
-      const dispose = history.listen((url) => transition(router, url, cb))
-
-      return () => {
-        dispose()
-        history = null
-        routes = []
-      }
+      let redirects = 0
+      return history.listen((url) => {
+        const route = router.match(url)
+        if (!route) {
+          redirects = 0
+          return
+        }
+        for (const r of route.data) {
+          if (r.redirect) {
+            if (++redirects > MAX_REDIRECTS) {
+              redirects = 0
+              throw new Error('space-router: too many redirects')
+            }
+            const target = typeof r.redirect === 'function' ? r.redirect(route) : r.redirect
+            return router.navigate({ url: router.href(target), replace: true })
+          }
+        }
+        redirects = 0
+        if (cb) cb(route)
+      })
     },
 
     navigate(to, curr) {
@@ -57,8 +69,14 @@ export function createRouter(options = {}) {
       let url = to.pathname || '/'
 
       if (to.params) {
-        Object.keys(to.params).forEach((param) => {
-          url = url.replace(':' + param, to.params[param])
+        const params = to.params
+        url = url.replace(PARAM_RE, (m, name, flag) => {
+          const v = params[name]
+          if (v == null) return m
+          if (flag === '+' || flag === '*') {
+            return String(v).split('/').map(encodeURIComponent).join('/')
+          }
+          return encodeURIComponent(v)
         })
       }
 
@@ -108,26 +126,6 @@ export function flatten(routeMap) {
   }
   addLevel(routeMap)
   return routes
-}
-
-function transition(router, url, onNavigated) {
-  const route = router.match(url)
-  if (route) {
-    for (const r of route.data) {
-      if (r.redirect) {
-        const url = redirectUrl(router, r.redirect, route)
-        return router.navigate({ url, replace: true })
-      }
-    }
-    if (onNavigated) onNavigated(route)
-  }
-}
-
-function redirectUrl(router, redirect, matchingRoute) {
-  if (typeof redirect === 'function') {
-    redirect = redirect(matchingRoute)
-  }
-  return router.href(redirect)
 }
 
 function data(routes, matchingRoute) {

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -1,0 +1,41 @@
+import test from 'ava'
+import { createHistory } from '../src/history'
+
+// history.js looks for `typeof window === 'undefined'` to pick memory vs browser
+// mode. To exercise the history-mode getUrl path we briefly stand up a tiny
+// DOM-ish global. We run serially so the globals don't leak across tests.
+function withFakeDom(href, fn) {
+  const previous = {
+    window: globalThis.window,
+    location: globalThis.location,
+    history: globalThis.history,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+  }
+  const url = new URL(href)
+  globalThis.window = { addEventListener() {}, removeEventListener() {} }
+  globalThis.location = { href, pathname: url.pathname, search: url.search }
+  globalThis.history = { pushState() {}, replaceState() {} }
+  globalThis.requestAnimationFrame = (cb) => cb()
+  try {
+    return fn()
+  } finally {
+    globalThis.window = previous.window
+    globalThis.location = previous.location
+    globalThis.history = previous.history
+    globalThis.requestAnimationFrame = previous.requestAnimationFrame
+  }
+}
+
+test.serial('getUrl in history mode preserves a # inside the hash fragment', (t) => {
+  withFakeDom('http://x.com/path#foo#bar', () => {
+    const h = createHistory({ mode: 'history', sync: true })
+    t.is(h.getUrl(), '/path#foo#bar')
+  })
+})
+
+test.serial('getUrl in history mode returns just pathname when no hash', (t) => {
+  withFakeDom('http://x.com/path', () => {
+    const h = createHistory({ mode: 'history', sync: true })
+    t.is(h.getUrl(), '/path')
+  })
+})

--- a/test/qs.test.js
+++ b/test/qs.test.js
@@ -1,0 +1,31 @@
+import test from 'ava'
+import { qs } from '../src'
+
+test('qs.parse handles a key without =', (t) => {
+  t.deepEqual(qs.parse('foo'), { foo: '' })
+})
+
+test('qs.parse keeps everything after the first = in the value', (t) => {
+  t.deepEqual(qs.parse('a=b=c'), { a: 'b=c' })
+})
+
+test('qs.parse decodes the key', (t) => {
+  t.deepEqual(qs.parse('foo%20bar=1'), { 'foo bar': '1' })
+})
+
+test('qs.parse decodes + as space (form-urlencoded)', (t) => {
+  t.deepEqual(qs.parse('q=hello+world'), { q: 'hello world' })
+})
+
+test('qs.parse handles empty pairs', (t) => {
+  t.deepEqual(qs.parse('a=1&&b=2'), { a: '1', b: '2' })
+})
+
+test('qs.stringify encodes the key', (t) => {
+  t.is(qs.stringify({ 'foo bar': 1 }), 'foo%20bar=1')
+})
+
+test('qs.stringify skips undefined and roundtrips with parse', (t) => {
+  t.is(qs.stringify({ a: 'x y', b: undefined, c: 'a/b' }), 'a=x%20y&c=a%2Fb')
+  t.deepEqual(qs.parse(qs.stringify({ a: 'x y', c: 'a/b' })), { a: 'x y', c: 'a/b' })
+})

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -130,6 +130,63 @@ test('redirects', (t) => {
   dispose()
 })
 
+test('href encodes params', (t) => {
+  const { router, dispose } = createTestRouter()
+
+  // slashes (and other special chars) get encoded so match round-trips
+  t.is(router.href({ pathname: '/user/:id', params: { id: 'a/b' } }), '/user/a%2Fb')
+  t.is(router.href({ pathname: '/user/:id', params: { id: 'a b' } }), '/user/a%20b')
+  t.is(router.href({ pathname: '/user/:id', params: { id: 'a?b' } }), '/user/a%3Fb')
+  t.is(router.match('/user/a%2Fb').params.id, 'a/b')
+
+  dispose()
+})
+
+test('href strips param flags', (t) => {
+  const { router, dispose } = createTestRouter()
+
+  t.is(router.href({ pathname: '/user/:id?', params: { id: '7' } }), '/user/7')
+  t.is(router.href({ pathname: '/files/:p+', params: { p: 'a/b' } }), '/files/a/b')
+  t.is(router.href({ pathname: '/files/:p*', params: { p: 'a/b/c' } }), '/files/a/b/c')
+  // splat encodes per segment
+  t.is(router.href({ pathname: '/files/:p+', params: { p: 'a b/c' } }), '/files/a%20b/c')
+
+  dispose()
+})
+
+test('href handles params with shared name prefixes', (t) => {
+  const { router, dispose } = createTestRouter()
+
+  t.is(router.href({ pathname: '/x/:idName/y/:id', params: { id: 'ID', idName: 'NAME' } }), '/x/NAME/y/ID')
+
+  dispose()
+})
+
+test('redirects: caps an infinite loop', (t) => {
+  const router = createRouter({ mode: 'memory', sync: true })
+  router.listen([
+    { path: '/a', redirect: '/b' },
+    { path: '/b', redirect: '/a' },
+  ])
+
+  t.throws(() => router.navigate('/a'), { message: /too many redirects/ })
+})
+
+test('navigate before listen does not throw', (t) => {
+  const router = createRouter({ mode: 'memory', sync: true })
+  t.notThrows(() => router.navigate('/foo'))
+  t.is(router.getUrl(), '/foo')
+})
+
+test('getUrl after dispose does not throw', (t) => {
+  const router = createRouter({ mode: 'memory', sync: true })
+  const dispose = router.listen([{ path: '/foo' }], () => {})
+  router.navigate('/foo')
+  dispose()
+  t.notThrows(() => router.getUrl())
+  t.is(router.getUrl(), '/foo')
+})
+
 function createTestRouter(cb, { withoutCatchAll = false } = {}) {
   const router = createRouter({ mode: 'memory', sync: true })
   const dispose = router.listen(


### PR DESCRIPTION
## Summary
- `href` does a single regex pass over `:name[+*?]` placeholders: encodes values (so slashes/spaces/etc. roundtrip with `match`), strips param flags, and avoids substring collisions when params share a name prefix (e.g. `:id` inside `:idName`).
- `qs.parse` decodes keys, keeps everything after the first `=` in the value, treats `+` as space, handles missing `=`. `qs.stringify` encodes keys.
- Redirect chains are capped at 10 hops and throw a clear error instead of stack-overflowing on cycles.
- The `history` object is created in `createRouter` (not in `listen`), so `getUrl` and `navigate` no longer crash before `listen` or after dispose.
- `getHash` no longer drops a `#` from inside the hash fragment (e.g. `#a#b` is preserved).
- Ships `index.d.ts` at the package root with a generic `Data` parameter on routes/router, wired up via `package.json#types`.

Each fix has a regression test in `test/router.test.js`, `test/qs.test.js`, or the new `test/history.test.js`.