### PR TITLE
Add navigation state

### DIFF
--- a/dist/history.d.ts
+++ b/dist/history.d.ts
@@ -1,9 +1,9 @@
 export type Mode = 'history' | 'hash' | 'memory';
 export interface History {
-    listen(onChange: (url: string) => void): () => void;
+    listen(onChange: (url: string, state: unknown) => void): () => void;
     getUrl(): string;
-    push(url: string): void;
-    replace(url: string): void;
+    push(url: string, state?: unknown): void;
+    replace(url: string, state?: unknown): void;
 }
 export interface CreateHistoryOptions {
     mode?: Mode;

--- a/dist/history.js
+++ b/dist/history.js
@@ -4,12 +4,20 @@ export function createHistory(options = {}) {
     let listener = null;
     let pending = false;
     const memory = [];
+    const memoryStates = [];
     if (typeof window === 'undefined') {
         mode = 'memory';
     }
     function emit() {
         if (listener)
-            listener(getUrl());
+            listener(getUrl(), getState());
+    }
+    function getState() {
+        if (mode === 'memory')
+            return memoryStates[memoryStates.length - 1];
+        if (mode === 'history')
+            return history.state;
+        return undefined;
     }
     function schedule() {
         if (sync)
@@ -37,13 +45,14 @@ export function createHistory(options = {}) {
                 off();
         };
     }
-    function go(url, replace) {
+    function go(url, replace, state) {
         url = url.replace(/^\/?#?\/?/, '/').replace(/\/$/, '') || '/';
         if (mode === 'history') {
-            history[replace ? 'replaceState' : 'pushState']({}, '', url);
+            history[replace ? 'replaceState' : 'pushState'](state ?? null, '', url);
             schedule();
         }
         else if (mode === 'hash') {
+            // hash mode has no native state support; the state argument is dropped.
             // hashchange only fires when the URL actually changes; if it doesn't,
             // we schedule the emit manually so navigation stays consistent with
             // history mode (where pushState is silent and we always schedule).
@@ -55,9 +64,11 @@ export function createHistory(options = {}) {
         else if (mode === 'memory') {
             if (replace) {
                 memory[memory.length - 1] = url;
+                memoryStates[memoryStates.length - 1] = state;
             }
             else {
                 memory.push(url);
+                memoryStates.push(state);
             }
             schedule();
         }
@@ -82,11 +93,11 @@ export function createHistory(options = {}) {
     return {
         listen,
         getUrl,
-        push(url) {
-            go(url);
+        push(url, state) {
+            go(url, false, state);
         },
-        replace(url) {
-            go(url, true);
+        replace(url, state) {
+            go(url, true, state);
         },
     };
 }

--- a/dist/router.d.ts
+++ b/dist/router.d.ts
@@ -8,6 +8,11 @@ export interface RouterOptions {
 }
 export interface Route<Data = Record<string, unknown>> extends MatchedRoute {
     data: Data[];
+    /**
+     * Opaque state passed via `navigate(to, { state })`. Populated when the
+     * route is delivered through `listen()`; `undefined` from `match()`.
+     */
+    state?: unknown;
 }
 export interface NavigateTarget {
     url?: string;
@@ -17,6 +22,13 @@ export interface NavigateTarget {
     hash?: string | null;
     replace?: boolean;
     merge?: boolean;
+    /**
+     * Opaque value stashed alongside the navigation. Forwarded to
+     * `history.pushState`/`replaceState` in history mode and surfaced as
+     * `route.state` in the listen callback. Ignored in hash mode (no DOM
+     * support).
+     */
+    state?: unknown;
 }
 export type To = string | NavigateTarget;
 export type Redirect<Data = Record<string, unknown>> = To | ((route: Route<Data>) => To);

--- a/dist/router.js
+++ b/dist/router.js
@@ -13,12 +13,13 @@ export function createRouter(options = {}) {
         listen(routeMap, cb) {
             routes = flatten(routeMap);
             let redirects = 0;
-            return history.listen((url) => {
+            return history.listen((url, state) => {
                 const route = router.match(url);
                 if (!route) {
                     redirects = 0;
                     return;
                 }
+                route.state = state;
                 for (const r of route.data) {
                     if (r.redirect) {
                         if (++redirects > MAX_REDIRECTS) {
@@ -26,7 +27,8 @@ export function createRouter(options = {}) {
                             throw new Error('space-router: too many redirects');
                         }
                         const target = typeof r.redirect === 'function' ? r.redirect(route) : r.redirect;
-                        return router.navigate({ url: router.href(target), replace: true });
+                        const targetState = typeof target === 'object' && target ? target.state : undefined;
+                        return router.navigate({ url: router.href(target), replace: true, state: targetState });
                     }
                 }
                 redirects = 0;
@@ -38,10 +40,10 @@ export function createRouter(options = {}) {
             const target = typeof to === 'string' ? { url: to } : to;
             const url = router.href(target, curr);
             if (target.replace) {
-                history.replace(url);
+                history.replace(url, target.state);
             }
             else {
-                history.push(url);
+                history.push(url, target.state);
             }
         },
         href(to, curr) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,10 +1,10 @@
 export type Mode = 'history' | 'hash' | 'memory'
 
 export interface History {
-  listen(onChange: (url: string) => void): () => void
+  listen(onChange: (url: string, state: unknown) => void): () => void
   getUrl(): string
-  push(url: string): void
-  replace(url: string): void
+  push(url: string, state?: unknown): void
+  replace(url: string, state?: unknown): void
 }
 
 export interface CreateHistoryOptions {
@@ -15,17 +15,24 @@ export interface CreateHistoryOptions {
 export function createHistory(options: CreateHistoryOptions = {}): History {
   const sync = !!options.sync
   let mode: Mode = options.mode || 'history'
-  let listener: ((url: string) => void) | null = null
+  let listener: ((url: string, state: unknown) => void) | null = null
   let pending = false
 
   const memory: string[] = []
+  const memoryStates: unknown[] = []
 
   if (typeof window === 'undefined') {
     mode = 'memory'
   }
 
   function emit() {
-    if (listener) listener(getUrl())
+    if (listener) listener(getUrl(), getState())
+  }
+
+  function getState(): unknown {
+    if (mode === 'memory') return memoryStates[memoryStates.length - 1]
+    if (mode === 'history') return history.state
+    return undefined
   }
 
   function schedule() {
@@ -38,7 +45,7 @@ export function createHistory(options: CreateHistoryOptions = {}): History {
     })
   }
 
-  function listen(onChange: (url: string) => void) {
+  function listen(onChange: (url: string, state: unknown) => void) {
     if (listener) throw new Error('Already listening')
     listener = onChange
     let off: (() => void) | undefined
@@ -52,12 +59,13 @@ export function createHistory(options: CreateHistoryOptions = {}): History {
     }
   }
 
-  function go(url: string, replace?: boolean) {
+  function go(url: string, replace?: boolean, state?: unknown) {
     url = url.replace(/^\/?#?\/?/, '/').replace(/\/$/, '') || '/'
     if (mode === 'history') {
-      history[replace ? 'replaceState' : 'pushState']({}, '', url)
+      history[replace ? 'replaceState' : 'pushState'](state ?? null, '', url)
       schedule()
     } else if (mode === 'hash') {
+      // hash mode has no native state support; the state argument is dropped.
       // hashchange only fires when the URL actually changes; if it doesn't,
       // we schedule the emit manually so navigation stays consistent with
       // history mode (where pushState is silent and we always schedule).
@@ -67,8 +75,10 @@ export function createHistory(options: CreateHistoryOptions = {}): History {
     } else if (mode === 'memory') {
       if (replace) {
         memory[memory.length - 1] = url
+        memoryStates[memoryStates.length - 1] = state
       } else {
         memory.push(url)
+        memoryStates.push(state)
       }
       schedule()
     }
@@ -99,11 +109,11 @@ export function createHistory(options: CreateHistoryOptions = {}): History {
   return {
     listen,
     getUrl,
-    push(url) {
-      go(url)
+    push(url, state) {
+      go(url, false, state)
     },
-    replace(url) {
-      go(url, true)
+    replace(url, state) {
+      go(url, true, state)
     },
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,6 +10,11 @@ export interface RouterOptions {
 
 export interface Route<Data = Record<string, unknown>> extends MatchedRoute {
   data: Data[]
+  /**
+   * Opaque state passed via `navigate(to, { state })`. Populated when the
+   * route is delivered through `listen()`; `undefined` from `match()`.
+   */
+  state?: unknown
 }
 
 export interface NavigateTarget {
@@ -20,6 +25,13 @@ export interface NavigateTarget {
   hash?: string | null
   replace?: boolean
   merge?: boolean
+  /**
+   * Opaque value stashed alongside the navigation. Forwarded to
+   * `history.pushState`/`replaceState` in history mode and surfaced as
+   * `route.state` in the listen callback. Ignored in hash mode (no DOM
+   * support).
+   */
+  state?: unknown
 }
 
 export type To = string | NavigateTarget
@@ -60,12 +72,13 @@ export function createRouter<Data = Record<string, unknown>>(options: RouterOpti
     listen(routeMap, cb) {
       routes = flatten(routeMap as RouteDefinition[])
       let redirects = 0
-      return history.listen((url) => {
+      return history.listen((url, state) => {
         const route = router.match(url)
         if (!route) {
           redirects = 0
           return
         }
+        route.state = state
         for (const r of route.data as Array<{ redirect?: Redirect<Data> }>) {
           if (r.redirect) {
             if (++redirects > MAX_REDIRECTS) {
@@ -73,7 +86,8 @@ export function createRouter<Data = Record<string, unknown>>(options: RouterOpti
               throw new Error('space-router: too many redirects')
             }
             const target = typeof r.redirect === 'function' ? r.redirect(route) : r.redirect
-            return router.navigate({ url: router.href(target), replace: true })
+            const targetState = typeof target === 'object' && target ? target.state : undefined
+            return router.navigate({ url: router.href(target), replace: true, state: targetState })
           }
         }
         redirects = 0
@@ -85,9 +99,9 @@ export function createRouter<Data = Record<string, unknown>>(options: RouterOpti
       const target: NavigateTarget = typeof to === 'string' ? { url: to } : to
       const url = router.href(target, curr)
       if (target.replace) {
-        history.replace(url)
+        history.replace(url, target.state)
       } else {
-        history.push(url)
+        history.push(url, target.state)
       }
     },
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -187,6 +187,33 @@ test('getUrl after dispose does not throw', (t) => {
   t.is(router.getUrl(), '/foo')
 })
 
+test('navigation state is delivered as route.state', (t) => {
+  const states: unknown[] = []
+  const router = createRouter({ mode: 'memory', sync: true })
+  router.listen([{ path: '*' }], (route) => {
+    states.push(route.state)
+  })
+
+  router.navigate({ url: '/a', state: { from: 'list', scrollY: 100 } })
+  router.navigate({ url: '/b', state: { from: 'detail' }, replace: true })
+  router.navigate('/c') // no state
+
+  t.deepEqual(states, [{ from: 'list', scrollY: 100 }, { from: 'detail' }, undefined])
+})
+
+test('redirects propagate state from object targets', (t) => {
+  const states: unknown[] = []
+  const router = createRouter({ mode: 'memory', sync: true })
+  router.listen([{ path: '/a', redirect: { url: '/b', state: { reason: 'a→b' } } }, { path: '/b' }], (route) => {
+    states.push(route.state)
+  })
+
+  router.navigate({ url: '/a', state: { reason: 'incoming' } })
+
+  // /a → /b redirect; final route is /b with the redirect target's state
+  t.deepEqual(states, [{ reason: 'a→b' }])
+})
+
 test('coalesces rapid async navigations into a single emit', async (t) => {
   const calls: string[] = []
   const router = createRouter({ mode: 'memory' })


### PR DESCRIPTION
## Summary

Closes the gap that we always called `pushState({}, '', url)` — apps couldn't stash scroll positions, \"where I came from\" context, or any other transient navigation metadata. Standard pattern that React Router and friends expose.

```ts
router.navigate({ url: '/page', state: { scrollY: 100, from: '/list' } })

router.listen(routes, (route) => {
  if (route.state?.scrollY) window.scrollTo(0, route.state.scrollY)
})
```

## What changed

- `NavigateTarget.state?: unknown` — pass through `navigate(...)` or `href(...)`.
- `Route.state?: unknown` — populated when a route is delivered through `listen()`. `match()` returns `state: undefined` (it's a pure URL → route mapping; no state without a navigation event).
- `history.push(url, state?)` / `history.replace(url, state?)` accept state and:
  - **history mode**: forwarded to `pushState`/`replaceState`; `popstate` reads it back automatically (state survives back/forward).
  - **memory mode**: tracked in a parallel `memoryStates[]` array.
  - **hash mode**: silently dropped — `location.assign('#x')` has no state slot in the DOM.
- Redirects: when the redirect target is an object with `state`, that state is propagated to the final navigation. State from the original incoming navigation is not auto-carried — the redirect target wins explicitly. Use a redirect function if you want to merge:
  ```ts
  { redirect: (route) => ({ url: '/b', state: { ...route.state, redirected: true } }) }
  ```

## Tests

- `route.state` is delivered for `navigate`, `replace`, and is `undefined` for navigations without state.
- Redirect targets propagate their `state`.